### PR TITLE
Link to design system instead of Elements

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -33,25 +33,9 @@
 
 			<ul class="list list-bullet body-text">
 				<li><a href="/docs/tutorials-and-examples">Example pages and documentation</a></li>
-				<li><a href="https://github.com/alphagov/govuk_prototype_kit">GitHub</a></li>
-			</ul>
-
-      <h2 class="heading-medium">Other resources</h2>
-
-			<ul class="list list-bullet body-text">
 				<li>
-					<a href="https://govuk-elements.herokuapp.com/snippets/">
-						Guide to GOV.UK Elements
-					</a>
-				</li>
-				<li>
-					<a href="https://www.gov.uk/service-manual">
-						Service design manual
-					</a>
-				</li>
-				<li>
-					<a href="https://www.gov.uk/design-principles">
-						Government Digital Service Design Principles
+					<a href="https://govuk-design-system-prototypes.cloudapps.digital/design-patterns/patterns/">
+						GOV.UK Design System
 					</a>
 				</li>
 			</ul>

--- a/docs/views/examples/template-question-page-blank.html
+++ b/docs/views/examples/template-question-page-blank.html
@@ -21,7 +21,7 @@
 
         <p>[Insert question content here]</p>
 
-        <p>[See <a href="https://govuk-elements.herokuapp.com/form-elements/">GOV.UK Elements</a> for examples]</p>
+        <p>[See <a href="https://govuk-design-system-prototypes.cloudapps.digital/design-patterns/patterns/">GOV.UK Design System</a> for examples]</p>
 
         <div class="form-group">
           <input class="govuk-c-button" type="submit" value="Continue">

--- a/docs/views/tutorials-and-examples.html
+++ b/docs/views/tutorials-and-examples.html
@@ -158,10 +158,10 @@
         </li>
       </ul>
 
-      <h2 class="heading-medium">GOV.UK Elements</h2>
+      <h2 class="heading-medium">GOV.UK Design System</h2>
 
       <p class="body-text">
-        <a href="https://govuk-elements.herokuapp.com/">GOV.UK Elements</a> is a guide to making your prototype look like a GOV.UK
+        <a href="https://govuk-design-system-prototypes.cloudapps.digital/design-patterns/patterns/">GOV.UK Design System</a> is a guide to making your prototype look like a GOV.UK
         service, including typography, forms and more.
       </p>
 


### PR DESCRIPTION
# PR #1 (Move to Frontend) must be merged first!

Updates links on:

 - Home page
 - Examples and docs page
 - Example question page

Also removes some links from the home page that don't seem useful to people prototyping (Github repo, Service manual)