### PR TITLE
Remove body-text class from html, add govuk-core-19 to body in application.scss

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -5,6 +5,10 @@ $path: "/public/images/";
 //Import GOV.UK Frontend
 @import "@govuk-frontend/all/all";
 
+body{
+  @include govuk-core-19;
+}
+
 // Take a look at in app/assets/sass/patterns/ to see which files are imported.
 // @import 'patterns/check-your-answers';
 // @import 'patterns/task-list';

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -14,24 +14,24 @@
         The GOV.UK prototype kit
         <span class="heading-secondary">{{releaseVersion}}</span>
       </h1>{{releaseVersion | log }}
-      <p class="body-text">
+      <p>
         This kit lets you rapidly create HTML prototypes of GOV.UK services.
       </p>
 
-      <p class="body-text">
+      <p>
         It contains all you need to prototype anything from simple static pages to complex, data-driven transactions.
       </p>
 
       <h2 class="heading-medium">About this page</h2>
 
-      <p class="body-text">We recommend you add links to your prototype to this page, rather than delete it.
+      <p>We recommend you add links to your prototype to this page, rather than delete it.
         You'll find this page in the kit at '/app/views/index.html'.</p>
 
-      <p class="body-text">You can change the service name by editing the file '/app/config.js'.</p>
+      <p>You can change the service name by editing the file '/app/config.js'.</p>
 
 			<h2 class="heading-medium">Examples and documentation</h2>
 
-			<ul class="list list-bullet body-text">
+			<ul class="list list-bullet">
 				<li><a href="/docs/tutorials-and-examples">Example pages and documentation</a></li>
 				<li>
 					<a href="https://govuk-design-system-prototypes.cloudapps.digital/design-patterns/patterns/">

--- a/docs/views/about.html
+++ b/docs/views/about.html
@@ -6,7 +6,7 @@ About - GOV.UK Prototype kit
 
 {% block content %}
 
-<main id="content" role="main" class="govuk-o-site-width-container body-text">
+<main id="content" role="main" class="govuk-o-site-width-container">
 
   <div class="breadcrumbs">
     <ol>
@@ -16,7 +16,7 @@ About - GOV.UK Prototype kit
 
   <div class="govuk-o-grid">
     <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
-      
+
       <h1 class="heading-xlarge">About</h1>
 
       <p class="lede">

--- a/docs/views/examples/confirmation-page.html
+++ b/docs/views/examples/confirmation-page.html
@@ -9,7 +9,7 @@
 <main id="content" role="main" class="govuk-o-site-width-container">
 
   <div class="govuk-o-grid">
-    <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds body-text">
+    <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
 
       <div class="govuk-c-panel govuk-c-panel--confirmation">
         <h1 class="heading-xlarge">

--- a/docs/views/examples/override-service-name.html
+++ b/docs/views/examples/override-service-name.html
@@ -10,7 +10,7 @@
 
 {% block content %}
 
-<main id="content" role="main" class="govuk-o-site-width-container body-text">
+<main id="content" role="main" class="govuk-o-site-width-container">
 
   {% include "includes/breadcrumb_examples.html" %}
 

--- a/docs/views/examples/start-page.html
+++ b/docs/views/examples/start-page.html
@@ -25,7 +25,7 @@
   </div>
 
   <div class="govuk-o-grid">
-    <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds body-text">
+    <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
 
       <h1 class="heading-xlarge">
         {% if serviceName %} {{ serviceName }} {% endif %}

--- a/docs/views/examples/template-content-page.html
+++ b/docs/views/examples/template-content-page.html
@@ -9,7 +9,7 @@
 <main id="content" role="main" class="govuk-o-site-width-container">
 
   <div class="govuk-o-grid">
-    <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds body-text">
+    <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
 
       <a class="link-back" href="/url/of/previous/page">Back</a>
 

--- a/docs/views/examples/template-question-page-blank.html
+++ b/docs/views/examples/template-question-page-blank.html
@@ -9,7 +9,7 @@
 <main id="content" role="main" class="govuk-o-site-width-container">
 
   <div class="govuk-o-grid">
-    <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds body-text">
+    <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
 
       <a class="link-back" href="/url/of/previous/page">Back</a>
 

--- a/docs/views/index.html
+++ b/docs/views/index.html
@@ -6,7 +6,7 @@ GOV.UK prototype kit
 
 {% block content %}
 
-<main id="content" role="main" class="govuk-o-site-width-container body-text">
+<main id="content" role="main" class="govuk-o-site-width-container">
 
   <div class="govuk-o-grid">
     <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">

--- a/docs/views/install.html
+++ b/docs/views/install.html
@@ -6,7 +6,7 @@ Getting started - GOV.UK Prototype kit
 
 {% block content %}
 
-<main id="content" role="main" class="govuk-o-site-width-container body-text">
+<main id="content" role="main" class="govuk-o-site-width-container">
 
   <div class="breadcrumbs">
     <ol>

--- a/docs/views/tutorials-and-examples.html
+++ b/docs/views/tutorials-and-examples.html
@@ -22,7 +22,7 @@
     <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
 
       <h2 class="heading-medium">Tutorials</h2>
-      <p class="body-text">
+      <p>
         These tutorials are being actively developed. If you have suggestions for improvements, we'd love to hear from you.
       </p>
     </div>
@@ -110,10 +110,10 @@
   <div class="govuk-o-grid">
     <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
       <h2 class="heading-medium">Page templates</h2>
-      <p class="body-text">
+      <p>
         Use these as the basis for your prototypes. We recommend making copies of the files rather than directly editing them.
       </p>
-      <p class="body-text">
+      <p>
         You can find them in your prototype folder, in /docs/views/examples
       </p>
 
@@ -160,7 +160,7 @@
 
       <h2 class="heading-medium">GOV.UK Design System</h2>
 
-      <p class="body-text">
+      <p>
         <a href="https://govuk-design-system-prototypes.cloudapps.digital/design-patterns/patterns/">GOV.UK Design System</a> is a guide to making your prototype look like a GOV.UK
         service, including typography, forms and more.
       </p>

--- a/lib/prototype-admin/clear-data.html
+++ b/lib/prototype-admin/clear-data.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 
-<main id="content" role="main" class="govuk-o-site-width-container body-text">
+<main id="content" role="main" class="govuk-o-site-width-container">
 
   <h1 class="heading-medium">
     Data cleared


### PR DESCRIPTION
body-text was adding extra spacing. We intend to add some sort of 'sensible default' to Frontend anyway, so this is simulating it in prototype kit scss for now.