### PR TITLE
Make macros available to all views

### DIFF
--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -1,5 +1,31 @@
 {% extends "govuk_template.html" %}
 
+{% from "breadcrumb/macro.njk"    import govukBreadcrumb %}
+{% from "button/macro.njk"        import govukButton %}
+{% from "checkbox/macro.njk"      import govukCheckbox %}
+{% from "cookie-banner/macro.njk" import govukCookieBanner %}
+{% from "date-input/macro.njk"    import govukDateInput %}
+{% from "details/macro.njk"       import govukDetails %}
+{% from "error-message/macro.njk" import govukErrorMessage %}
+{% from "error-summary/macro.njk" import govukErrorSummary %}
+{% from "fieldset/macro.njk"      import govukFieldset %}
+{% from "file-upload/macro.njk"   import govukFileUpload %}
+{% from "input/macro.njk"         import govukInput %}
+{% from "inset-text/macro.njk"    import govukInsetText %}
+{% from "label/macro.njk"         import govukLabel %}
+{% from "legal-text/macro.njk"    import govukLegalText %}
+{% from "link/macro.njk"          import govukLink %}
+{% from "list/macro.njk"          import govukList %}
+{% from "panel/macro.njk"         import govukPanel %}
+{% from "phase-banner/macro.njk"  import govukPhaseBanner %}
+{% from "previous-next/macro.njk" import govukPreviousNext %}
+{% from "radio/macro.njk"         import govukRadio %}
+{% from "select/macro.njk"        import govukSelect %}
+{% from "skip-link/macro.njk"     import govukSkipLink %}
+{% from "table/macro.njk"         import govukTable %}
+{% from "tag/macro.njk"           import govukTag %}
+{% from "textarea/macro.njk"      import govukTextarea %}
+
 {% block head %}
   {% include "includes/head.html" %}
 {% endblock %}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "marked": "^0.3.6",
     "minimist": "1.2.0",
     "notifications-node-client": "^3.0.0",
-    "nunjucks": "^2.5.2",
+    "nunjucks": "^3.0.1",
     "portscanner": "^2.1.1",
     "prompt": "^1.0.0",
     "readdir": "0.0.13",

--- a/server.js
+++ b/server.js
@@ -61,7 +61,7 @@ if (env === 'production' && useAuth === 'true') {
 }
 
 // Set up App
-var appViews = [path.join(__dirname, '/app/views/'), path.join(__dirname, '/lib/')]
+var appViews = [path.join(__dirname, '/app/views/'), path.join(__dirname, '/lib/'), path.join(__dirname, '/node_modules/@govuk-frontend/')]
 
 var nunjucksAppEnv = nunjucks.configure(appViews, {
   autoescape: true,


### PR DESCRIPTION
Note - this bumps the version of Nunjucks from 2 to 3, as Frontend macros require this.

We have avoided upgrading because of this issue:

https://github.com/mozilla/nunjucks/issues/696

However probably fine to change here in private beta so that frontend macros work. We can always revisit the version of Nunjucks on both projects if needed.