### PR TITLE
Remove app-c, -o and -h layer prefixes

### DIFF
--- a/app/assets/sass/patterns/related-items.scss
+++ b/app/assets/sass/patterns/related-items.scss
@@ -1,11 +1,11 @@
 // This is a GOV.UK Publishing specific component that
 // can be seen at http://govuk-static.herokuapp.com/component-guide/related_items
 
-.app-c-related-items {
+.app-related-items {
   border-top: 10px solid $govuk-blue;
   padding-top: $govuk-spacing-scale-2;
 }
 
-.app-c-related-items li {
+.app-related-items li {
   margin-bottom: $govuk-spacing-scale-2;
 }

--- a/docs/views/examples/start-page.html
+++ b/docs/views/examples/start-page.html
@@ -63,7 +63,7 @@
 
       <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
 
-        <aside class="app-c-related-items" role="complementary">
+        <aside class="app-related-items" role="complementary">
           <h2 class="govuk-heading-m" id="subsection-title">
             Subsection
           </h2>


### PR DESCRIPTION
To maintain consistency with the coding conventions in Frontend, where we're removing these prefixes.
This PR removes all app related prefixes

Trello ticket: https://trello.com/c/vmx7ykwm/872-update-prototype-kit-styles-to-follow-new-conventions