### PR TITLE
Add Code highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+New features:
+
+- [#39 Add code highlighting](https://github.com/alphagov/govuk-prototype-kit-private-beta/pull/39)
 # 7.0.0-beta.6
 
 Breaking changes:

--- a/docs/assets/sass/docs.scss
+++ b/docs/assets/sass/docs.scss
@@ -7,3 +7,9 @@
 .app-\!-db {
   display: block !important;
 }
+
+// adjust code block font-size to 19px
+.hljs {
+  font-size: 19px;
+  line-height: 25px;
+}

--- a/docs/documentation_routes.js
+++ b/docs/documentation_routes.js
@@ -31,8 +31,7 @@ router.get('/install/:page', function (req, res) {
   }
   redirectMarkdown(req.params.page, res)
   var doc = fs.readFileSync(path.join(__dirname, '/documentation/install/', req.params.page + '.md'), 'utf8')
-  var html = marked(doc)
-  res.render('install_template', {'document': html})
+  res.render('install_template', {'document': utils.markdownToHtml(doc)})
 })
 
 // Cookies and Privacy policy are markdown

--- a/docs/views/includes/head.html
+++ b/docs/views/includes/head.html
@@ -2,6 +2,7 @@
 <!--[if gt IE 8]><!--><link href="/public/stylesheets/application.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
 <!--[if lte IE 8]><link href="/public/stylesheets/docs-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
 <!--[if gt IE 8]><!--><link href="/public/stylesheets/docs.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
+<link href="/public/vendor/highlight/default.css" media="screen" rel="stylesheet" type="text/css" />
 
 {% if promoMode == 'true' and analyticsId %}
 	{% include "includes/analytics.html" %}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -220,8 +220,7 @@ exports.matchMdRoutes = function (req, res) {
   var docsPath = '/../docs/documentation/'
   if (fs.existsSync(path.join(__dirname, docsPath, req.params[0] + '.md'), 'utf8')) {
     var doc = fs.readFileSync(path.join(__dirname, docsPath, req.params[0] + '.md'), 'utf8')
-    var html = marked(doc)
-    res.render('documentation_template', {'document': html})
+    res.render('documentation_template', {'document': this.markdownToHtml(doc)})
     return true
   }
   return false
@@ -273,4 +272,19 @@ exports.autoStoreData = function (req, res, next) {
   }
 
   next()
+}
+
+// convert markdown to HTML
+exports.markdownToHtml = function (document) {
+  var hljs = require('highlight.js')
+  var renderer = new marked.Renderer()
+
+  // add highlight classes to code block
+  renderer.code = function (code, language) {
+    language = language || 'bash'
+    return '<pre><code class="hljs ' + language + '">' +
+      hljs.highlight(language, code).value +
+      '</code></pre>'
+  }
+  return marked(document, { renderer: renderer })
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "gulp-sass": "3.1.0",
     "gulp-sourcemaps": "^2.6.0",
     "gulp-util": "^3.0.7",
+    "highlight.js": "^9.12.0",
     "marked": "^0.3.6",
     "minimist": "1.2.0",
     "notifications-node-client": "^3.0.0",

--- a/server.js
+++ b/server.js
@@ -90,6 +90,9 @@ app.use('/public', express.static(path.join(__dirname, '/node_modules/govuk_temp
 // load govuk-frontend 'all' js
 app.use('/public/javascripts', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/frontend')))
 
+// hightlightJS styles
+app.use('/public/vendor/highlight', express.static(path.join(__dirname, '/node_modules/highlight.js/styles')))
+
 // Elements refers to icon folder instead of images folder
 app.use(favicon(path.join(__dirname, 'node_modules', 'govuk_template_jinja', 'assets', 'images', 'favicon.ico')))
 


### PR DESCRIPTION
Adding highlight.js code highlighting (same as Design system)
Added renderer to marked to add correct classes
Inline default highlight.js css

Trello ticket: https://trello.com/c/IIEvTvmy/681-fix-code-style-in-the-prototype-kit