### PR TITLE
Fix and move GitHub links from home page and nav to the About page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 New features:
 
 - [#39 Add code highlighting](https://github.com/alphagov/govuk-prototype-kit-private-beta/pull/39)
+
+Bug fixes:
+
+- [#47 Fix and move GitHub links from home page and nav to the About page](https://github.com/alphagov/govuk-prototype-kit-private-beta/pull/47)
+
 # 7.0.0-beta.6
 
 Breaking changes:

--- a/docs/views/about.html
+++ b/docs/views/about.html
@@ -35,6 +35,7 @@ About - GOV.UK Prototype kit
           <li><a href="https://ukgovernmentdigital.slack.com/messages/prototype-kit-dev/">Slack channel for developers of the prototype kit</a></li>
         </ul>
 
+        <p>You can also report issues, or contribute code on <a href="https://github.com/alphagov/govuk-prototype-kit-private-beta">GitHub</a>.</p>
 
         <h2 class="govuk-heading-l">Principles</h2>
 

--- a/docs/views/index.html
+++ b/docs/views/index.html
@@ -32,7 +32,7 @@ GOV.UK prototype kit
         </p>
 
       </div>
-        <div class="govuk-grid-column-one-third govuk-!-mt-r6">
+      <div class="govuk-grid-column-one-third govuk-!-mt-r6">
 
         <h2 class="govuk-heading-m"><a href="/docs/tutorials-and-examples">Tutorials and examples</a></h2>
         <p>
@@ -40,29 +40,17 @@ GOV.UK prototype kit
         </p>
 
       </div>
-        <div class="govuk-grid-column-one-third govuk-!-mt-r6">
+      <div class="govuk-grid-column-one-third govuk-!-mt-r6">
 
         <h2 class="govuk-heading-m"><a href="/docs/about">About</a></h2>
         <p>
-          About the kit, principles, privacy.
+          Get support, Prototype Kit principles, privacy.
         </p>
 
       </div>
 
     </div>
-    <div class="govuk-grid-row">
 
-        <div class="govuk-grid-column-one-third govuk-!-mt-r6">
-
-        <h2 class="govuk-heading-m"><a href="https://github.com/alphagov/govuk_prototype_kit">GitHub</a></h2>
-        <p>
-          Source code, contributing, bugs.
-        </p>
-
-      </div>
-
-
-    </div>
   </main>
 </div>
 

--- a/docs/views/layout.html
+++ b/docs/views/layout.html
@@ -35,7 +35,6 @@
           <li><a href="/docs/install">Install</a></li>
           <li><a href="/docs/tutorials-and-examples">Tutorials and examples</a></li>
           <li><a href="/docs/about">About</a></li>
-          <li><a href="https://github.com/alphagov/govuk_prototype_kit">GitHub</a></li>
         </ul>
 
       </nav>


### PR DESCRIPTION
GitHub link doesn't seem like a major user need, so I've moved it off the home page and main navigation into About. Also corrected it to the new repo.

![image](https://user-images.githubusercontent.com/1132904/40376238-c7ea6f92-5de5-11e8-8675-923c3677865f.png)
