### PR TITLE
Do not track users who have enabled 'DoNotTrack'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ New features:
 
 - [#39 Add code highlighting](https://github.com/alphagov/govuk-prototype-kit-private-beta/pull/39)
 
+- [#52 Do not track users who have enabled 'DoNotTrack'](https://github.com/alphagov/govuk-prototype-kit-private-beta/pull/52)
+
 Bug fixes:
 
 - [#47 Fix and move GitHub links from home page and nav to the About page](https://github.com/alphagov/govuk-prototype-kit-private-beta/pull/47)

--- a/docs/views/layout.html
+++ b/docs/views/layout.html
@@ -2,14 +2,14 @@
 
 {% block head %}
   {% include "includes/head.html" %}
-  {% if promoMode == 'true' and gtmId %}
+  {% if doNotTrackEnabled == false and promoMode == 'true' and gtmId %}
     {% include "includes/tracking_head.html" %}
   {% endif %}
 {% endblock %}
 
 
 {% block body_start %}
-  {% if promoMode == 'true' and gtmId %}
+  {% if doNotTrackEnabled == false and promoMode == 'true' and gtmId %}
     {% include "includes/tracking_body.html" %}
   {% endif %}
 {% endblock %}

--- a/server.js
+++ b/server.js
@@ -122,7 +122,15 @@ app.use(bodyParser.urlencoded({
   extended: true
 }))
 
-// Add variables that are available in all views
+// Add global variable to determine if DoNotTrack is enabled.
+// This indicates a user has explicitly opted-out of tracking.
+// Therefore we can avoid injecting third-party scripts that do not respect this decision.
+app.use(function (req, res, next) {
+  // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/DNT
+  app.locals.doNotTrackEnabled = (req.header('DNT') === '1')
+  next()
+})
+
 app.locals.analyticsId = analyticsId
 app.locals.gtmId = gtmId
 app.locals.asset_path = '/public/'


### PR DESCRIPTION
Adds a guard around Google Tag Manager script to prevent it from initialising,
for users who have indicated they do not want to be tracked.

https://trello.com/c/jHVUmpdx/957-do-not-track-users-with-donottrack-enabled