### PR TITLE
Add javascript to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+New features:
+
+- [#55 Add GOV.UK Frontend JavaScript to documentation pages](https://github.com/alphagov/govuk-prototype-kit-private-beta/pull/55)
+
 # 7.0.0-beta.7
 
 Breaking changes:

--- a/docs/views/examples/check-your-answers-page.html
+++ b/docs/views/examples/check-your-answers-page.html
@@ -162,7 +162,7 @@
           By submitting this notification you are confirming that, to the best of your knowledge, the details you are providing are correct.
         </p>
 
-        <a href="confirmation-page" class="govuk-button">Accept and send application</a>
+        <a href="confirmation-page" class="govuk-button" role="button">Accept and send application</a>
 
       </div>
     </div>

--- a/docs/views/includes/scripts.html
+++ b/docs/views/includes/scripts.html
@@ -2,6 +2,7 @@
 <!--[if lte IE 8]><script src="/public/javascripts/bind.js"></script><![endif]-->
 <script src="/public/javascripts/jquery-1.11.3.js"></script>
 <script src="/public/javascripts/docs.js"></script>
+<script src="/public/javascripts/all.js"></script>
 
 {% if useAutoStoreData %}
   <script src="/public/javascripts/auto-store-data.js"></script>


### PR DESCRIPTION
This PR:
- adds govuk-frontend JavaScript to the `/docs` pages.
- adds `role="button"` for the anchors styled as buttons so the button.js shim initialises

Test URL: `/docs/examples/check-your-answers-page`

This fixes #51.

[Trello card](https://trello.com/c/S84vYp0J)