### PR TITLE
Design system messaging

### DIFF
--- a/docs/views/index.html
+++ b/docs/views/index.html
@@ -21,6 +21,25 @@ GOV.UK prototype kit
 
   </div>
 
+  <hr class="govuk-section-break govuk-section-break--visible">
+
+  <div class="govuk-grid-row govuk-!-margin-top-6 govuk-!-margin-bottom-4">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h2 class="govuk-heading-m">What’s new</h2>
+      <p>
+        Version 7 of the GOV.UK Prototype Kit uses the new GOV.UK Design System which replaces GOV.UK Elements.
+      </p>
+
+      <p>
+        Visit the <a href="https://govuk-design-system-production.cloudapps.digital/">GOV.UK Design System</a> for guidance and examples.
+      </p>
+
+    </div>
+  </div>
+
+  <hr class="govuk-section-break govuk-section-break--visible">
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third govuk-!-margin-top-6">
 


### PR DESCRIPTION
Depends on #56 being merged first.

Add a message about the GOV.UK Design System to the Prototype Kit home page, so people who start their journey there are aware they need to use the Design System, not Elements.

Needs a content review.

Screenshot:

![image](https://user-images.githubusercontent.com/1132904/41597914-b395e336-73c6-11e8-94b0-684cc21adf21.png)
