### PR TITLE
Fix markdown-docs-layout-template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 Bug fixes:
 
+- [#63 Fix markdown-docs-layout-template](https://github.com/alphagov/govuk-prototype-kit-private-beta/pull/63)
+
 - [#62 Add cookie-banner styles and javascript](https://github.com/alphagov/govuk-prototype-kit-private-beta/pull/62)
+
 
 # 7.0.0-beta.8
 

--- a/docs/views/markdown-docs-layout.html
+++ b/docs/views/markdown-docs-layout.html
@@ -14,12 +14,12 @@ Install - GOV.UK Prototype kit
     ]
   }) }}
 {% endblock %}
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <div class="app-prose-scope">
-          {{document | safe}}
-        </div>
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="app-prose-scope">
+        {{document | safe}}
       </div>
     </div>
-
+  </div>
 {% endblock %}


### PR DESCRIPTION
It was missing the start of the `content` block