### PR TITLE
DO NOT MERGE add backward compatibility

### DIFF
--- a/gulp/sass.js
+++ b/gulp/sass.js
@@ -20,6 +20,20 @@ gulp.task('sass', function () {
   .pipe(gulp.dest(config.paths.public + '/stylesheets/'))
 })
 
+// Sass for backward compatibility with Elements
+gulp.task('sass-legacy', function () {
+  return gulp.src('lib/backward-compatibility/assets/sass/*.scss')
+  .pipe(sourcemaps.init())
+  .pipe(sass({outputStyle: 'expanded',
+    includePaths: [
+      'node_modules/govuk_frontend_toolkit/stylesheets',
+      'node_modules/govuk-elements-sass/public/sass',
+      'node_modules/govuk_template_jinja/assets/stylesheets'
+    ]}).on('error', sass.logError))
+  .pipe(sourcemaps.write())
+  .pipe(gulp.dest(config.paths.public + '/stylesheets/'))
+})
+
 gulp.task('sass-documentation', function () {
   return gulp.src(config.paths.docsAssets + '/sass/*.scss')
   .pipe(sourcemaps.init())

--- a/gulp/tasks.js
+++ b/gulp/tasks.js
@@ -17,6 +17,7 @@ gulp.task('default', function (done) {
 gulp.task('generate-assets', function (done) {
   runSequence('clean',
                 'sass',
+                'sass-legacy',
                 'sass-documentation',
                 'copy-assets',
                 'copy-documentation-assets', done)

--- a/lib/backward-compatibility/assets/sass/elements.scss
+++ b/lib/backward-compatibility/assets/sass/elements.scss
@@ -1,0 +1,31 @@
+// Path to assets for use with the file-url function
+// in the govuk frontend toolkit's url-helpers partial
+$path: "/public/images/";
+
+// Import GOV.UK elements from /govuk-modules/, this will import the frontend toolkit and some base styles.
+// Take a look in /govuk-modules/_govuk-elements.scss to see which files are imported.
+@import 'govuk-elements';
+
+// Take a look at in app/assets/sass/patterns/ to see which files are imported.
+@import 'patterns/check-your-answers';
+@import 'patterns/task-list';
+
+// Related items
+// (These styles will be moved to GOV.UK elements, duplicating here for now.)
+.govuk-related-items {
+  margin-top: $gutter;
+  border-top: 10px solid $govuk-blue;
+  padding-top: 5px;
+
+  .heading-medium {
+    margin-top: 0.3em;
+    margin-bottom: 0.5em;
+  }
+
+  li {
+    margin-bottom: 10px;
+    list-style-type: none;
+  }
+}
+
+// Add extra styles here, or re-organise the Sass files in whichever way makes most sense to you

--- a/lib/backward-compatibility/assets/sass/patterns/_check-your-answers.scss
+++ b/lib/backward-compatibility/assets/sass/patterns/_check-your-answers.scss
@@ -1,0 +1,95 @@
+// Recommended - Use these styles for the check your answers pattern
+.govuk-check-your-answers {
+
+  @include media(desktop) {
+    display: table;
+  }
+
+  > * {
+    position: relative;
+    border-bottom: 1px solid $border-colour;
+
+    @include media(desktop) {
+      display: table-row;
+      border-bottom-width: 0;
+    }
+
+    > * {
+      display: block;
+
+      @include media(desktop) {
+        display: table-cell;
+        border-bottom: 1px solid $border-colour;
+        padding: em(12, 19) em(20, 19) em(9, 19) 0; // copied from Elements' td padding
+        margin: 0;
+      }
+    }
+
+    @include media(desktop) {
+      &:first-child > * {
+        padding-top: 0;
+      }
+    }
+  }
+
+  .cya-question {
+    font-weight: bold;
+    margin: em(12, 19) 4em em(4,19) 0;
+    // top: from Elements' td
+    // right: due to length of "change" link (adjust if you change the link to be much longer)
+    // bottom: by eye
+    // using margin instead of padding because of easier absolutely positioning of .change
+  }
+
+  > *:first-child .cya-question {
+    margin-top: 0;
+  }
+
+  @include media(desktop) {
+    // to make group of q&a line up horizontally (unless there is just one group)
+    &.cya-questions-short,
+    &.cya-questions-long {
+      width: 100%;
+    }
+
+    // recommended for mostly short questions
+    &.cya-questions-short .cya-question {
+      width: 30%;
+    }
+
+    // recommended for mostly long questions
+    &.cya-questions-long .cya-question {
+      width: 50%;
+    }
+  }
+
+  .cya-answer {
+    padding-bottom: em(9, 19); // from Elements' td
+  }
+
+  .cya-change {
+    text-align: right;
+    position: absolute;
+    top: 0;
+    right: 0;
+
+    @include media(desktop) {
+      position: static;
+      padding-right: 0;
+    }
+  }
+
+}
+
+// Deprecated - these styles will be removed in a later release
+.check-your-answers {
+  td {
+    @include core-19;
+    vertical-align: top;
+  }
+  .change-answer {
+    text-align: right;
+    font-weight: bold;
+    padding-right: 0;
+  }
+}

--- a/lib/backward-compatibility/assets/sass/patterns/_task-list.scss
+++ b/lib/backward-compatibility/assets/sass/patterns/_task-list.scss
@@ -1,0 +1,73 @@
+// Task list pattern
+
+// Override column width for tablet and up
+.column-minimum {
+  @include media(tablet) {
+    min-width: 600px;
+  }
+}
+
+// Spacing to the left of the task list
+$task-list-indent: 35px;
+
+.task-list {
+  margin-top: $gutter;
+  @include media(tablet) {
+    margin-top: ($gutter * 2);
+  }
+}
+
+
+.task-list-section {
+  display: table;
+
+  @include bold-24;
+  padding-bottom: ($gutter / 6);
+}
+
+.task-list-section-number {
+  display: table-cell;
+  padding-right: ($gutter / 6);
+
+  @include media(tablet) {
+    min-width: $task-list-indent;
+    padding-right: 0;
+  }
+}
+
+
+.task-list-items {
+  margin-bottom: $gutter;
+  @include media(tablet) {
+    margin-bottom: ($gutter * 2);
+  }
+
+  @include media(tablet) {
+    padding-left: $task-list-indent;
+  }
+}
+
+.task-list-item {
+  border-bottom: 1px solid $border-colour;
+  padding-top: $gutter-one-third;
+  padding-bottom: $gutter-one-third;
+  @extend %contain-floats;
+}
+
+.task-list-item:first-child {
+  border-top: 1px solid $border-colour;
+}
+
+
+.task-name {
+  width: $two-thirds;
+  float: left;
+}
+
+.task-completed {
+  @include phase-tag;
+
+  float: right;
+  margin-right: 0;
+  padding-top: 3px;
+}

--- a/lib/backward-compatibility/views/includes/head.html
+++ b/lib/backward-compatibility/views/includes/head.html
@@ -1,2 +1,10 @@
 <!--[if lte IE 8]><link href="/public/stylesheets/application-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
 <!--[if gt IE 8]><!--><link href="/public/stylesheets/elements.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->
+
+<!--
+If you are updating an old prototype (version 6 or older) and you added your own
+styles to app/assets/application.scss, rename it to application-elements.scss and
+uncomment the line below
+-->
+
+<!-- <link href="/public/stylesheets/application-elements.css" media="screen" rel="stylesheet" type="text/css" /> -->

--- a/lib/backward-compatibility/views/includes/head.html
+++ b/lib/backward-compatibility/views/includes/head.html
@@ -1,0 +1,2 @@
+<!--[if lte IE 8]><link href="/public/stylesheets/application-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
+<!--[if gt IE 8]><!--><link href="/public/stylesheets/elements.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->

--- a/lib/backward-compatibility/views/includes/scripts.html
+++ b/lib/backward-compatibility/views/includes/scripts.html
@@ -1,0 +1,11 @@
+<!-- Javascript -->
+<!--[if lte IE 8]><script src="/public/javascripts/bind.js"></script><![endif]-->
+<script src="/public/javascripts/jquery-1.11.3.js"></script>
+<script src="/public/javascripts/govuk/details.polyfill.js"></script>
+<script src="/public/javascripts/govuk/shim-links-with-button-role.js"></script>
+<script src="/public/javascripts/govuk/show-hide-content.js"></script>
+<script src="/public/javascripts/application.js"></script>
+
+{% if useAutoStoreData %}
+  <script src="/public/javascripts/auto-store-data.js"></script>
+{% endif %}

--- a/lib/backward-compatibility/views/layout-elements.html
+++ b/lib/backward-compatibility/views/layout-elements.html
@@ -1,0 +1,55 @@
+{% extends "govuk_template.html" %}
+
+{% block head %}
+  {% include "./includes/head.html" %}
+{% endblock %}
+
+{% block cookie_message %}
+  <p>{{cookieText | safe }}</p>
+{% endblock %}
+
+{% block proposition_header %}
+
+  <div class="header-proposition">
+    <div class="content">
+      <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
+      <nav id="proposition-menu">
+        <a href="/" id="proposition-name">
+          {# Set serviceName in config.js. Use a block to override on a page. #}
+          {% block service_name %}
+            {% if serviceName %} {{ serviceName }} {% endif %}
+          {% endblock %}
+        </a>
+        <!--
+        <ul id="proposition-links">
+          <li><a href="url-to-page-1" class="active">Navigation item #1</a></li>
+          <li><a href="url-to-page-2">Navigation item #2</a></li>
+        </ul>
+        -->
+      </nav>
+    </div>
+  </div>
+
+{% endblock %}
+
+{% block header_class %}
+  with-proposition
+{% endblock %}
+
+{% block footer_support_links %}
+  {% if useAutoStoreData %}
+    <ul>
+      <li>
+        <a href="/prototype-admin/clear-data">Clear data</a>
+      </li>
+    </ul>
+  {% endif %}
+{% endblock %}
+
+{% block body_end %}
+  {% block scripts %}
+    {% include "./includes/scripts.html" %}
+    {% block page_scripts %}{% endblock %}
+  {% endblock %}
+  <!-- GOV.UK Prototype kit {{releaseVersion}} -->
+{% endblock %}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "test": "gulp test && npm run lint"
   },
   "dependencies": {
-    "govuk-frontend": "0.0.32",
     "basic-auth": "^1.0.3",
     "basic-auth-connect": "^1.0.0",
     "body-parser": "^1.14.1",
@@ -22,6 +21,10 @@
     "express": "4.15.2",
     "express-session": "^1.13.0",
     "express-writer": "0.0.4",
+    "govuk-elements-sass": "^3.1.2",
+    "govuk-frontend": "0.0.32",
+    "govuk_frontend_toolkit": "^7.5.0",
+    "govuk_template_jinja": "^0.24.0",
     "gulp": "^3.9.1",
     "gulp-clean": "^0.3.2",
     "gulp-mocha": "^4.3.1",

--- a/server.js
+++ b/server.js
@@ -65,7 +65,10 @@ var appViews = [
   path.join(__dirname, '/app/views/'),
   path.join(__dirname, '/lib/'),
   path.join(__dirname, '/node_modules/govuk-frontend'), // template path
-  path.join(__dirname, '/node_modules/govuk-frontend/components')
+  path.join(__dirname, '/node_modules/govuk-frontend/components'),
+  // backward compatibility
+  path.join(__dirname, '/lib/backward-compatibility/views'),
+  path.join(__dirname, '/node_modules/govuk_template_jinja/views/layouts')
 ]
 
 var nunjucksAppEnv = nunjucks.configure(appViews, {
@@ -84,6 +87,8 @@ app.set('view engine', 'html')
 // Middleware to serve static assets
 app.use('/assets', express.static(path.join(__dirname, '/node_modules/govuk-frontend/assets')))
 app.use('/public', express.static(path.join(__dirname, '/public')))
+// Backward compatibility
+app.use('/public', express.static(path.join(__dirname, '/node_modules/govuk_template_jinja/assets')))
 
 // load govuk-frontend 'all' js
 app.use('/public/javascripts', express.static(path.join(__dirname, '/node_modules/govuk-frontend')))


### PR DESCRIPTION
This work allows people with large old prototypes to use the new prototype kit without having to rewrite everything.

On old pages, users would change this line:

`{% extends "layout.html" %}`

to this:

`{% extends "layout-elements.html" %}`

This layout is in `lib/backward-compatibility` along with all the necessary assets and views from version 6 of the kit. When a page is using `layout-elements` it now uses the old technology - Elements, Frontend toolkit, GOV.UK Template. It does not allow you to use Frontend.

The idea is people can upgrade page by page as needed, and any new pages would use the new technology in Frontend.

**Issues:**

~~1. If people have added their own css to `app/assets/application.css` how do they use that?~~
2. I've used the words `backward-compatibility`, `legacy`, and `elements` at various points. We should probably just decide on one, maybe? Possibly two because `elements` is a well understood concept but not entirely technically accurate - this work provides more than just elements.
3. Some JavaScript and images are missing