### PR TITLE
use correct casing for 'Prototype Kit' throughout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ New features:
 
 Bug fixes:
 
+- [#67 Use correct casing for 'Prototype Kit' throughout](https://github.com/alphagov/govuk-prototype-kit-private-beta/pull/67)
+
 - [#63 Fix markdown-docs-layout-template](https://github.com/alphagov/govuk-prototype-kit-private-beta/pull/63)
 
 - [#62 Add cookie-banner styles and javascript](https://github.com/alphagov/govuk-prototype-kit-private-beta/pull/62)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,10 @@ We do have a few guidelines to bear in mind.
 
 ## Community
 
-We have two Slack channels for the Prototype kit. You'll need a government email address to join them.
+We have two Slack channels for the Prototype Kit. You'll need a government email address to join them.
 
-* [Slack channel for users of the prototype kit](https://ukgovernmentdigital.slack.com/messages/prototype-kit/)
-* [Slack channel for developers of the prototype kit](https://ukgovernmentdigital.slack.com/messages/prototype-kit-dev/)
+* [Slack channel for users of the Prototype Kit](https://ukgovernmentdigital.slack.com/messages/prototype-kit/)
+* [Slack channel for developers of the Prototype Kit](https://ukgovernmentdigital.slack.com/messages/prototype-kit-dev/)
 
 ## Raising bugs
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# GOV.UK Prototype kit
+# GOV.UK Prototype Kit
 
 Go to the [GOV.UK Prototype Kit site](https://govuk-prototype-kit-beta.herokuapp.com) to download the latest version and read the documentation.
 
-## About the prototype kit
+## About the Prototype Kit
 
-The prototype kit provides a simple way to make interactive prototypes that look like pages on GOV.UK. These prototypes can be used to show ideas to people you work with, and to do user research.
+The Prototype Kit provides a simple way to make interactive prototypes that look like pages on GOV.UK. These prototypes can be used to show ideas to people you work with, and to do user research.
 
 Read the [project principles](https://govuk-prototype-kit-beta.herokuapp.com-beta/docs/principles).
 
@@ -21,7 +21,7 @@ You must protect user privacy at all times, even when using prototypes. Prototyp
 
 ## Community
 
-We have two Slack channels for the Prototype kit. You'll need a government email address to join them.
+We have two Slack channels for the Prototype Kit. You'll need a government email address to join them.
 
-* [Slack channel for users of the prototype kit](https://ukgovernmentdigital.slack.com/messages/prototype-kit/)
-* [Slack channel for developers of the prototype kit](https://ukgovernmentdigital.slack.com/messages/prototype-kit-dev/)
+* [Slack channel for users of the Prototype Kit](https://ukgovernmentdigital.slack.com/messages/prototype-kit/)
+* [Slack channel for developers of the Prototype Kit](https://ukgovernmentdigital.slack.com/messages/prototype-kit-dev/)

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -1,14 +1,14 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  GOV.UK prototype kit
+  GOV.UK Prototype Kit
 {% endblock %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
-        The GOV.UK prototype kit
+        The GOV.UK Prototype Kit
         <span class="govuk-caption-xl">{{releaseVersion}}</span>
       </h1>{{releaseVersion | log }}
       <p>

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -31,7 +31,7 @@
 {% endblock %}
 
 {% block pageTitle %}
-  GOV.UK prototype kit
+  GOV.UK Prototype Kit
 {% endblock %}
 {% block header %}
   {# Set serviceName in config.js. #}
@@ -64,5 +64,5 @@
     {% include "includes/scripts.html" %}
     {% block page_scripts %}{% endblock %}
   {% endblock %}
-  <!-- GOV.UK Prototype kit {{releaseVersion}} -->
+  <!-- GOV.UK Prototype Kit {{releaseVersion}} -->
 {% endblock %}

--- a/docs/documentation/install/introduction.md
+++ b/docs/documentation/install/introduction.md
@@ -10,7 +10,7 @@ This guide is a work in progress. Please help [contribute](https://github.com/al
 
 ## Introduction
 
-The prototype kit provides a simple way to make interactive prototypes that look and feel like pages on GOV.UK. These prototypes can be used to design and lay out pages, and to use in user research.
+The Prototype Kit provides a simple way to make interactive prototypes that look and feel like pages on GOV.UK. These prototypes can be used to design and lay out pages, and to use in user research.
 
 
 

--- a/docs/documentation/install/run-the-kit.md
+++ b/docs/documentation/install/run-the-kit.md
@@ -24,7 +24,7 @@ In your web browser, visit <a href="http://localhost:3000" target="_blank">http:
 
 You should see the prototype welcome page.
 
-![Screenshot of the prototype kit homepage](/public/images/docs/prototype-kit-homepage.png)
+![Screenshot of the Prototype Kit homepage](/public/images/docs/prototype-kit-homepage.png)
 
 ## Quitting the kit
 

--- a/docs/documentation/principles.md
+++ b/docs/documentation/principles.md
@@ -1,6 +1,6 @@
 # Principles
 
-The prototype kit:
+The Prototype Kit:
 
 - is designed for prototyping, not for production code
 - requires minimal skills to get started: HTML, CSS

--- a/docs/documentation/setting-up-git.md
+++ b/docs/documentation/setting-up-git.md
@@ -4,7 +4,7 @@ Git helps track changes in code and lets you undo mistakes or identify bugs. It�
 
 This guide will walk you through setting up a git repo (repository) and committing your work so that you can publish your prototype on the web.
 
-> You don’t *have* to use Git to use the prototype kit, but it will be really useful if you learn some basics.
+> You don’t *have* to use Git to use the Prototype Kit, but it will be really useful if you learn some basics.
 
 > Git is not the same as GitHub. Git stores versions of your work, and lets you collaborate more easily with others. GitHub puts it all online with a nice web interface.
 

--- a/docs/documentation/updating-the-kit.md
+++ b/docs/documentation/updating-the-kit.md
@@ -8,7 +8,7 @@ If you have made any changes outside the `app` folder, this process will destroy
 
 ### Steps
 
-Download the latest prototype kit zip file from GitHub
+Download the latest Prototype Kit zip file from GitHub
 
 In your project, delete everything apart from the `app` and `.git` folder
 
@@ -118,13 +118,13 @@ In terminal:
 npm start
 ```
 
-If you still have an error, you can [raise an issue within github](https://github.com/alphagov/govuk_prototype_kit/issues) or ask in the [Slack channel for users of the prototype kit](https://ukgovernmentdigital.slack.com/messages/prototype-kit/) by providing as much information as you can about the error and the computer you are attempting to run the prototyping kit on.
+If you still have an error, you can [raise an issue within github](https://github.com/alphagov/govuk_prototype_kit/issues) or ask in the [Slack channel for users of the Prototype Kit](https://ukgovernmentdigital.slack.com/messages/prototype-kit/) by providing as much information as you can about the error and the computer you are attempting to run the prototyping kit on.
 
 ---
 
 ## Converting old prototypes
 
-Earlier versions of the prototype kit used a different templating language called Mustache.
+Earlier versions of the Prototype Kit used a different templating language called Mustache.
 
 Converting Mustache templates to Nunjucks ones is relatively simple. Here are the main things you'll need to do:
 
@@ -141,13 +141,13 @@ Becomes…
 ### Template blocks
 
     {{$pageTitle}}
-        GOV.UK prototype kit
+        GOV.UK Prototype Kit
     {{/pageTitle}}
 
 Becomes…
 
     {% block pageTitle %}
-        GOV.UK prototype kit
+        GOV.UK Prototype Kit
     {% endblock %}
 
 and

--- a/docs/documentation/writing-css.md
+++ b/docs/documentation/writing-css.md
@@ -1,6 +1,6 @@
 # Writing CSS
 
-CSS used in the prototype kit is written in the SCSS syntax of [Sass](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#syntax). 
+CSS used in the Prototype Kit is written in the SCSS syntax of [Sass](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#syntax). 
 
 ## Sass
 
@@ -10,7 +10,7 @@ SCSS was chosen because you can paste CSS into it without breaking it which is u
 
 ## Writing code
 
-You write your Sass in [app/assets/sass](../app/assets/sass) and the prototype kit will compile it into the CSS used in your page (found in /public/stylesheets). The app watches your files so this will happen automatically.
+You write your Sass in [app/assets/sass](../app/assets/sass) and the Prototype Kit will compile it into the CSS used in your page (found in /public/stylesheets). The app watches your files so this will happen automatically.
 
 There is already a CSS file included to use called [application.scss](../app/assets/sass/application.scss) which compiles into [application.css](../public/stylesheets/application.css). Note that Sass files are identified by the `.scss` extension.
 

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -1,6 +1,6 @@
 # Linting
 
-The prototype kit uses [standardjs](http://standardjs.com/), an opinionated JavaScript linter. All JavaScript files follow its conventions, and it runs on CI to ensure that new pull requests are in line with them.
+The Prototype Kit uses [standardjs](http://standardjs.com/), an opinionated JavaScript linter. All JavaScript files follow its conventions, and it runs on CI to ensure that new pull requests are in line with them.
 
 ## Running standard manually
 
@@ -32,9 +32,9 @@ There are [official guides for most of the popular editors](http://standardjs.co
 
 ## Do I need to respect this?
 
-If you want to submit a pull request to the prototype kit, your code will need to pass the linter.
+If you want to submit a pull request to the Prototype Kit, your code will need to pass the linter.
 
-If you're just using the prototype kit in a separate project, then no, you aren't forced to use standard, or any other linter for that matter. Just write code as you would normally.
+If you're just using the Prototype Kit in a separate project, then no, you aren't forced to use standard, or any other linter for that matter. Just write code as you would normally.
 
 ## Why lint?
 

--- a/docs/views/about.html
+++ b/docs/views/about.html
@@ -2,14 +2,14 @@
 {% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
 
 {% block pageTitle %}
-About - GOV.UK Prototype kit
+About - GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
-        "text": "GOV.UK prototype kit",
+        "text": "GOV.UK Prototype Kit",
         "href": "/docs"
       }
     ]
@@ -22,22 +22,22 @@ About - GOV.UK Prototype kit
       <h1 class="govuk-heading-xl">About</h1>
 
       <p class="govuk-body-l">
-        The prototype kit provides a simple way to make interactive prototypes that look like pages on GOV.UK. These prototypes can be used to show ideas to people you work with, and to do user research
+        The Prototype Kit provides a simple way to make interactive prototypes that look like pages on GOV.UK. These prototypes can be used to show ideas to people you work with, and to do user research
       </p>
 
       <h2 class="govuk-heading-l">Community</h2>
 
-      <p>We have two Slack channels for the Prototype kit. You'll need a government email address to join.</p>
+      <p>We have two Slack channels for the Prototype Kit. You'll need a government email address to join.</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li><a href="https://ukgovernmentdigital.slack.com/messages/prototype-kit/">Slack channel for users of the prototype kit</a></li>
-        <li><a href="https://ukgovernmentdigital.slack.com/messages/prototype-kit-dev/">Slack channel for developers of the prototype kit</a></li>
+        <li><a href="https://ukgovernmentdigital.slack.com/messages/prototype-kit/">Slack channel for users of the Prototype Kit</a></li>
+        <li><a href="https://ukgovernmentdigital.slack.com/messages/prototype-kit-dev/">Slack channel for developers of the Prototype Kit</a></li>
       </ul>
 
       <p>You can also report issues, or contribute code on <a href="https://github.com/alphagov/govuk-prototype-kit-private-beta">GitHub</a>.</p>
 
       <h2 class="govuk-heading-l">Principles</h2>
 
-      <p>The prototype kit:</p>
+      <p>The Prototype Kit:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>is designed for prototyping, not for production code</li>
         <li>requires minimal skills to get started: HTML, CSS</li>

--- a/docs/views/documentation_template.html
+++ b/docs/views/documentation_template.html
@@ -2,14 +2,14 @@
 {% from "breadcrumbs/macro.njk"   import govukBreadcrumbs %}
 
 {% block pageTitle %}
-Documentation - GOV.UK Prototype kit
+Documentation - GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
-        "text": "GOV.UK prototype kit",
+        "text": "GOV.UK Prototype Kit",
         "href": "/docs"
       }
     ]

--- a/docs/views/examples/override-service-name.html
+++ b/docs/views/examples/override-service-name.html
@@ -2,7 +2,7 @@
 {% from 'breadcrumbs/macro.njk' import govukBreadcrumbs %}
 
 {% block pageTitle %}
-  GOV.UK prototype kit - override service name
+  GOV.UK Prototype Kit - override service name
 {% endblock %}
 
 {% set serviceName %}
@@ -14,7 +14,7 @@
   {{ govukBreadcrumbs({
     "items": [
       {
-        "text": "GOV.UK prototype kit",
+        "text": "GOV.UK Prototype Kit",
         "href": "/docs"
       },
       {

--- a/docs/views/examples/pass-data/index.html
+++ b/docs/views/examples/pass-data/index.html
@@ -11,7 +11,7 @@
 {{ govukBreadcrumbs({
     "items": [
       {
-        "text": "GOV.UK prototype kit",
+        "text": "GOV.UK Prototype Kit",
         "href": "/docs"
       },
       {

--- a/docs/views/examples/template-data.html
+++ b/docs/views/examples/template-data.html
@@ -9,7 +9,7 @@
   {{ govukBreadcrumbs({
     "items": [
       {
-        "text": "GOV.UK prototype kit",
+        "text": "GOV.UK Prototype Kit",
         "href": "/docs"
       },
       {

--- a/docs/views/index.html
+++ b/docs/views/index.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-GOV.UK prototype kit
+GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}
@@ -11,7 +11,7 @@ GOV.UK prototype kit
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-xl">GOV.UK prototype kit</h1>
+      <h1 class="govuk-heading-xl">GOV.UK Prototype Kit</h1>
 
       <p class="govuk-body-l">
         Rapidly create HTML prototypes of GOV.UK services.

--- a/docs/views/install.html
+++ b/docs/views/install.html
@@ -1,14 +1,14 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-Getting started - GOV.UK Prototype kit
+Getting started - GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
-        "text": "GOV.UK prototype kit",
+        "text": "GOV.UK Prototype Kit",
         "href": "/docs"
       }
     ]

--- a/docs/views/install_template.html
+++ b/docs/views/install_template.html
@@ -2,7 +2,7 @@
 {% from "breadcrumbs/macro.njk"   import govukBreadcrumbs %}
 
 {% block pageTitle %}
-Install - GOV.UK Prototype kit
+Install - GOV.UK Prototype Kit
 {% endblock %}
 
 
@@ -10,7 +10,7 @@ Install - GOV.UK Prototype kit
   {{ govukBreadcrumbs({
     "items": [
       {
-        "text": "GOV.UK prototype kit",
+        "text": "GOV.UK Prototype Kit",
         "href": "/docs"
       },
       {

--- a/docs/views/layout.html
+++ b/docs/views/layout.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block pageTitle %}
-  GOV.UK prototype kit
+  GOV.UK Prototype Kit
 {% endblock %}
 
 
@@ -69,5 +69,5 @@
 
 {% block bodyEnd %}
   {% include "includes/scripts.html" %}
-  <!-- GOV.UK Prototype kit {{releaseVersion}} -->
+  <!-- GOV.UK Prototype Kit {{releaseVersion}} -->
 {% endblock %}

--- a/docs/views/markdown-docs-layout.html
+++ b/docs/views/markdown-docs-layout.html
@@ -1,14 +1,14 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-Install - GOV.UK Prototype kit
+Install - GOV.UK Prototype Kit
 {% endblock %}
 
 {% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
       {
-        "text": "GOV.UK prototype kit",
+        "text": "GOV.UK Prototype Kit",
         "href": "/docs"
       }
     ]

--- a/docs/views/tutorials-and-examples.html
+++ b/docs/views/tutorials-and-examples.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  GOV.UK prototype kit
+  GOV.UK Prototype Kit
 {% endblock %}
 
 
@@ -9,7 +9,7 @@
   {{ govukBreadcrumbs({
     "items": [
       {
-        "text": "GOV.UK prototype kit",
+        "text": "GOV.UK Prototype Kit",
         "href": "/docs"
       }
     ]

--- a/server.js
+++ b/server.js
@@ -163,7 +163,7 @@ app.get('/prototype-admin/clear-data', function (req, res) {
 
 // Redirect root to /docs when in promo mode.
 if (promoMode === 'true') {
-  console.log('Prototype kit running in promo mode')
+  console.log('Prototype Kit running in promo mode')
 
   app.locals.cookieText = 'GOV.UK uses cookies to make the site simpler. <a href="/docs/cookies">Find out more about cookies</a>'
 
@@ -171,7 +171,7 @@ if (promoMode === 'true') {
     res.redirect('/docs')
   })
 
-  // Allow search engines to index the prototype kit promo site
+  // Allow search engines to index the Prototype Kit promo site
   app.get('/robots.txt', function (req, res) {
     res.type('text/plain')
     res.send('User-agent: *\nAllow: /')
@@ -193,13 +193,13 @@ if (promoMode === 'true') {
 // Load routes (found in app/routes.js)
 if (typeof (routes) !== 'function') {
   console.log(routes.bind)
-  console.log('Warning: the use of bind in routes is deprecated - please check the prototype kit documentation for writing routes.')
+  console.log('Warning: the use of bind in routes is deprecated - please check the Prototype Kit documentation for writing routes.')
   routes.bind(app)
 } else {
   app.use('/', routes)
 }
 
-// Redirect to the zip of the latest release of the prototype kit on GitHub
+// Redirect to the zip of the latest release of the Prototype Kit on GitHub
 app.get('/prototype-admin/download-latest', function (req, res) {
   var url = utils.getLatestRelease()
   res.redirect(url)
@@ -208,7 +208,7 @@ app.get('/prototype-admin/download-latest', function (req, res) {
 if (useDocumentation) {
   // Copy app locals to documentation app locals
   documentationApp.locals = Object.assign({}, app.locals)
-  documentationApp.locals.serviceName = 'Prototype kit'
+  documentationApp.locals.serviceName = 'Prototype Kit'
 
   // Create separate router for docs
   app.use('/docs', documentationApp)
@@ -247,7 +247,7 @@ app.post(/^\/([^.]+)$/, function (req, res) {
   res.redirect('/' + req.params[0])
 })
 
-console.log('\nGOV.UK Prototype kit v' + releaseVersion)
+console.log('\nGOV.UK Prototype Kit v' + releaseVersion)
 console.log('\nNOTICE: the kit is for building prototypes, do not use it for production services.')
 
 // Find a free port and start the server

--- a/test/spec/sanity-checks.js
+++ b/test/spec/sanity-checks.js
@@ -8,7 +8,7 @@ var assert = require('assert')
 /**
  * Basic sanity checks on the dev server
  */
-describe('The prototype kit', function () {
+describe('The Prototype Kit', function () {
   it('should generate assets into the /public folder', function () {
     assert.doesNotThrow(function () {
       fs.accessSync(path.resolve(__dirname, '../../public/javascripts/application.js'))


### PR DESCRIPTION
This standardises the casing for 'Prototype Kit'.

In another PR we may want to say 'GOV.UK Prototype Kit' in more places.