### PR TITLE
Use back-link component without text parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ New features:
 
 - [#68 Reintroduce task list pattern](https://github.com/alphagov/govuk-prototype-kit-private-beta/pull/68)
 
+- [#73 Use back-link component without text parameter](https://github.com/alphagov/govuk-prototype-kit-private-beta/pull/73)
+
 Bug fixes:
 
 - [#67 Use correct casing for 'Prototype Kit' throughout](https://github.com/alphagov/govuk-prototype-kit-private-beta/pull/67)

--- a/docs/views/examples/check-your-answers-page.html
+++ b/docs/views/examples/check-your-answers-page.html
@@ -6,8 +6,7 @@
 
 {% block beforeContent %}
   {{ govukBackLink({
-    href: "/url/of/previous/page",
-    text: "Back"
+    href: "/url/of/previous/page"
   }) }}
 {% endblock %}
 

--- a/docs/views/examples/template-content-page.html
+++ b/docs/views/examples/template-content-page.html
@@ -6,8 +6,7 @@
 
 {% block beforeContent %}
   {{ govukBackLink({
-    href: "/url/of/previous/page",
-    text: "Back"
+    href: "/url/of/previous/page"
   }) }}
 {% endblock %}
 {% block content %}

--- a/docs/views/examples/template-question-page-blank.html
+++ b/docs/views/examples/template-question-page-blank.html
@@ -6,8 +6,7 @@
 
 {% block beforeContent %}
   {{ govukBackLink({
-    href: "/url/of/previous/page",
-    text: "Back"
+    href: "/url/of/previous/page"
   }) }}
 {% endblock %}
 


### PR DESCRIPTION
Back-link component can be used without specifying the `text` parameter as we set it by default to 'Back'